### PR TITLE
Improve strings escape sequences support

### DIFF
--- a/syntax/aiken.vim
+++ b/syntax/aiken.vim
@@ -51,7 +51,7 @@ syn match aikenOperator "\(+\|-\|*\|%\)"
 
 " Literals
 " − Strings
-syn region aikenString start="\"" skip="\\\\." end="\"" contains=@spell
+syn region aikenString start="\"" skip="\\." end="\"" contains=@spell
 " − Numbers
 syn match aikenInt     "-\?\<\d\+\>"
 syn match aikenBinary  "\<0b[0-1_]\+\>"


### PR DESCRIPTION
A single backslash is used for escape sequences, for example "\"".